### PR TITLE
[B_L4S5I_IOT01A] update to support OCTOSPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,69 @@
 # MX25R6435F
-Arduino library to support the Quad-SPI NOR Flash memory MX25R6435F
+Arduino library to support the Quad-SPI NOR Flash memory MX25R6435F using the Quad SPI flash memories interface. Since library version 2.0.0 and [STM32 core](https://github.com/stm32duino/Arduino_Core_STM32) version 2.0.0 the OctoSPI Flash memories interface can also be used.
 
 ## API
 
 The library provides the following API:
 
-* begin()
-* end()
-* write()
-* read()
-* mapped()
-* erase()
-* eraseChip()
-* eraseSector()
-* suspendErase()
-* resumeErase()
-* sleep()
-* wakeup()
-* status()
-* info()
-* length()
+* `begin()`
+* `end()`
+* `write()`
+* `read()`
+* `mapped()`
+* `erase()`
+* `eraseChip()`
+* `eraseSector()`
+* `suspendErase()`
+* `resumeErase()`
+* `sleep()`
+* `wakeup()`
+* `status()`
+* `info()`
+* `length()`
+
+Since library version 2.0.0, xSPI pins can be defined at sketch level, using:
+
+* To redefine the default one before call of `begin()`:
+
+  * `setDx(uint32_t data0, uint32_t data1, uint32_t data2, uint32_t data3)`
+  * `setDx(PinName data0, PinName data1, PinName data2, PinName data3)`
+  * `setSSEL(uint32_t ssel)`
+  * `setSSEL(PinName ssel)`
+  * `setSCLK(uint32_t sclk)`
+  * `setSCLK(PinName sclk)`
+
+  *Code snippet:*
+```C++
+  MX25R6435F.setDx(PE12, PE13, PE14, PE15); // using pin number
+  MX25R6435F.setSCLK(PE10);
+  MX25R6435F.setSSEL(PE_11); // using PinName
+  MX25R6435F.begin();
+```
+
+* or using the `begin()` method:
+
+  * `MX25R6435FClass(uint8_t data0, uint8_t data1, uint8_t data2, uint8_t data3, uint8_t clk, uint8_t ssel)`
+
+  *Code snippet:*
+```C++
+  MX25R6435F.begin(PE12, PE13, PE14, PE15, PE10, PE11);
+```
+
+* or by redefining the default pins definition (using [build_opt.h](https://github.com/stm32duino/wiki/wiki/Customize-build-options-using-build_opt.h) or [hal_conf_extra.h](https://github.com/stm32duino/wiki/wiki/HAL-configuration#customize-hal-or-variant-definition)):
+
+  * `MX25R6435F_D0`
+  * `MX25R6435F_D1`
+  * `MX25R6435F_D2`
+  * `MX25R6435F_D3`
+  * `MX25R6435F_SCLK`
+  * `MX25R6435F_SSEL`
 
 ## Examples
 
-3 sketches provide basic examples to show how to use the library API.  
-demo.ino uses basic read/write functions.  
-eraseChip.ino erases all data present in the memory.  
-memoryMappedMode.ino shows how to use the mapped mode.  
+3 sketches provide basic examples to show how to use the library API:
+* `demo.ino` uses basic read/write functions.
+* `eraseChip.ino` erases all data present in the memory.
+* `memoryMappedMode.ino` shows how to use the mapped mode.
 
 ## Documentation
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -26,6 +26,9 @@ wakeup	KEYWORD2
 status	KEYWORD2
 info	KEYWORD2
 length	KEYWORD2
+setDx KEYWORD2
+setSCLK KEYWORD2
+setSSEL KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/src/MX25R6435F.cpp
+++ b/src/MX25R6435F.cpp
@@ -9,29 +9,13 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+  * <h2><center>&copy; Copyright (c) 2020 STMicroelectronics.
+  * All rights reserved.</center></h2>
   *
-  * Redistribution and use in source and binary forms, with or without modification,
-  * are permitted provided that the following conditions are met:
-  *   1. Redistributions of source code must retain the above copyright notice,
-  *      this list of conditions and the following disclaimer.
-  *   2. Redistributions in binary form must reproduce the above copyright notice,
-  *      this list of conditions and the following disclaimer in the documentation
-  *      and/or other materials provided with the distribution.
-  *   3. Neither the name of STMicroelectronics nor the names of its contributors
-  *      may be used to endorse or promote products derived from this software
-  *      without specific prior written permission.
-  *
-  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
   *
   ******************************************************************************
   */
@@ -55,6 +39,7 @@ void MX25R6435FClass::begin(uint8_t data0, uint8_t data1, uint8_t data2, uint8_t
 
   if (BSP_QSPI_Init(&_qspi) == MEMORY_OK) {
     initDone = 1;
+  }
 }
 
 void MX25R6435FClass::end(void)
@@ -70,11 +55,13 @@ uint32_t MX25R6435FClass::write(uint8_t data, uint32_t addr)
 
 uint32_t MX25R6435FClass::write(uint8_t *pData, uint32_t addr, uint32_t size)
 {
-  if((pData == NULL) || (initDone == 0))
+  if ((pData == NULL) || (initDone == 0)) {
     return 0;
+  }
 
-  if(BSP_QSPI_Write(&_qspi, pData, addr, size) != MEMORY_OK)
+  if (BSP_QSPI_Write(&_qspi, pData, addr, size) != MEMORY_OK) {
     return 0;
+  }
 
   return size;
 }
@@ -90,70 +77,79 @@ uint8_t MX25R6435FClass::read(uint32_t addr)
 
 void MX25R6435FClass::read(uint8_t *pData, uint32_t addr, uint32_t size)
 {
-  if((pData != NULL) && (initDone == 1))
+  if ((pData != NULL) && (initDone == 1)) {
     BSP_QSPI_Read(&_qspi, pData, addr, size);
+  }
 }
 
 uint8_t *MX25R6435FClass::mapped(void)
 {
-  if(BSP_QSPI_EnableMemoryMappedMode(&_qspi) != MEMORY_OK)
+  if (BSP_QSPI_EnableMemoryMappedMode(&_qspi) != MEMORY_OK) {
     return NULL;
+  }
 
   return (uint8_t *)MEMORY_MAPPED_ADDRESS;
 }
 
 uint8_t MX25R6435FClass::erase(uint32_t addr)
 {
-  if(initDone == 0)
+  if (initDone == 0) {
     return MEMORY_ERROR;
+  }
 
   return BSP_QSPI_Erase_Block(&_qspi, addr);
 }
 
 uint8_t MX25R6435FClass::eraseChip(void)
 {
-  if(initDone == 0)
+  if (initDone == 0) {
     return MEMORY_ERROR;
+  }
 
   return BSP_QSPI_Erase_Chip(&_qspi);
 }
 
 uint8_t MX25R6435FClass::eraseSector(uint32_t sector)
 {
-  if(initDone == 0)
+  if (initDone == 0) {
     return MEMORY_ERROR;
+  }
 
   return BSP_QSPI_Erase_Sector(&_qspi, sector);
 }
 
 uint8_t MX25R6435FClass::suspendErase(void)
 {
-  if(initDone == 0)
+  if (initDone == 0) {
     return MEMORY_ERROR;
+  }
 
   return BSP_QSPI_SuspendErase(&_qspi);
 }
 
 uint8_t MX25R6435FClass::resumeErase(void)
 {
-  if(initDone == 0)
+  if (initDone == 0) {
     return MEMORY_ERROR;
+  }
 
   return BSP_QSPI_ResumeErase(&_qspi);
 }
 
 uint8_t MX25R6435FClass::sleep(void)
 {
-  if(initDone == 0)
+  if (initDone == 0) {
     return MEMORY_ERROR;
+  }
 
   return BSP_QSPI_EnterDeepPowerDown(&_qspi);
 }
 
 uint8_t MX25R6435FClass::wakeup(void)
 {
-  if(initDone == 0)
+  if (initDone == 0) {
     return MEMORY_ERROR;
+  }
 
   return BSP_QSPI_LeaveDeepPowerDown(&_qspi);
 }
@@ -170,30 +166,30 @@ uint32_t MX25R6435FClass::info(memory_info_t info)
 
   BSP_QSPI_GetInfo(&pInfo);
 
-  switch(info){
+  switch (info) {
     case MEMORY_SIZE:
       res = pInfo.FlashSize;
-    break;
+      break;
 
     case MEMORY_SECTOR_SIZE:
       res = pInfo.EraseSectorSize;
-    break;
+      break;
 
     case MEMORY_SECTOR_NUMBER:
       res = pInfo.EraseSectorsNumber;
-    break;
+      break;
 
     case MEMORY_PAGE_SIZE:
       res = pInfo.ProgPageSize;
-    break;
+      break;
 
     case MEMORY_PAGE_NUMBER:
       res = pInfo.ProgPagesNumber;
-    break;
+      break;
 
     default:
       res = 0;
-    break;
+      break;
   }
 
   return res;

--- a/src/MX25R6435F.cpp
+++ b/src/MX25R6435F.cpp
@@ -42,18 +42,24 @@ MX25R6435FClass MX25R6435F;
 
 MX25R6435FClass::MX25R6435FClass(): initDone(0)
 {
-
 }
 
-void MX25R6435FClass::begin(void)
+void MX25R6435FClass::begin(uint8_t data0, uint8_t data1, uint8_t data2, uint8_t data3, uint8_t sclk, uint8_t ssel)
 {
-  if(BSP_QSPI_Init() == MEMORY_OK)
+  _qspi.pin_d0 = digitalPinToPinName(data0);
+  _qspi.pin_d1 = digitalPinToPinName(data1);
+  _qspi.pin_d2 = digitalPinToPinName(data2);
+  _qspi.pin_d3 = digitalPinToPinName(data3);
+  _qspi.pin_sclk = digitalPinToPinName(sclk);
+  _qspi.pin_ssel = digitalPinToPinName(ssel);
+
+  if (BSP_QSPI_Init(&_qspi) == MEMORY_OK) {
     initDone = 1;
 }
 
 void MX25R6435FClass::end(void)
 {
-  BSP_QSPI_DeInit();
+  BSP_QSPI_DeInit(&_qspi);
   initDone = 0;
 }
 
@@ -67,7 +73,7 @@ uint32_t MX25R6435FClass::write(uint8_t *pData, uint32_t addr, uint32_t size)
   if((pData == NULL) || (initDone == 0))
     return 0;
 
-  if(BSP_QSPI_Write(pData, addr, size) != MEMORY_OK)
+  if(BSP_QSPI_Write(&_qspi, pData, addr, size) != MEMORY_OK)
     return 0;
 
   return size;
@@ -85,12 +91,12 @@ uint8_t MX25R6435FClass::read(uint32_t addr)
 void MX25R6435FClass::read(uint8_t *pData, uint32_t addr, uint32_t size)
 {
   if((pData != NULL) && (initDone == 1))
-    BSP_QSPI_Read(pData, addr, size);
+    BSP_QSPI_Read(&_qspi, pData, addr, size);
 }
 
 uint8_t *MX25R6435FClass::mapped(void)
 {
-  if(BSP_QSPI_EnableMemoryMappedMode() != MEMORY_OK)
+  if(BSP_QSPI_EnableMemoryMappedMode(&_qspi) != MEMORY_OK)
     return NULL;
 
   return (uint8_t *)MEMORY_MAPPED_ADDRESS;
@@ -101,7 +107,7 @@ uint8_t MX25R6435FClass::erase(uint32_t addr)
   if(initDone == 0)
     return MEMORY_ERROR;
 
-  return BSP_QSPI_Erase_Block(addr);
+  return BSP_QSPI_Erase_Block(&_qspi, addr);
 }
 
 uint8_t MX25R6435FClass::eraseChip(void)
@@ -109,7 +115,7 @@ uint8_t MX25R6435FClass::eraseChip(void)
   if(initDone == 0)
     return MEMORY_ERROR;
 
-  return BSP_QSPI_Erase_Chip();
+  return BSP_QSPI_Erase_Chip(&_qspi);
 }
 
 uint8_t MX25R6435FClass::eraseSector(uint32_t sector)
@@ -117,7 +123,7 @@ uint8_t MX25R6435FClass::eraseSector(uint32_t sector)
   if(initDone == 0)
     return MEMORY_ERROR;
 
-  return BSP_QSPI_Erase_Sector(sector);
+  return BSP_QSPI_Erase_Sector(&_qspi, sector);
 }
 
 uint8_t MX25R6435FClass::suspendErase(void)
@@ -125,7 +131,7 @@ uint8_t MX25R6435FClass::suspendErase(void)
   if(initDone == 0)
     return MEMORY_ERROR;
 
-  return BSP_QSPI_SuspendErase();
+  return BSP_QSPI_SuspendErase(&_qspi);
 }
 
 uint8_t MX25R6435FClass::resumeErase(void)
@@ -133,7 +139,7 @@ uint8_t MX25R6435FClass::resumeErase(void)
   if(initDone == 0)
     return MEMORY_ERROR;
 
-  return BSP_QSPI_ResumeErase();
+  return BSP_QSPI_ResumeErase(&_qspi);
 }
 
 uint8_t MX25R6435FClass::sleep(void)
@@ -141,7 +147,7 @@ uint8_t MX25R6435FClass::sleep(void)
   if(initDone == 0)
     return MEMORY_ERROR;
 
-  return BSP_QSPI_EnterDeepPowerDown();
+  return BSP_QSPI_EnterDeepPowerDown(&_qspi);
 }
 
 uint8_t MX25R6435FClass::wakeup(void)
@@ -149,12 +155,12 @@ uint8_t MX25R6435FClass::wakeup(void)
   if(initDone == 0)
     return MEMORY_ERROR;
 
-  return BSP_QSPI_LeaveDeepPowerDown();
+  return BSP_QSPI_LeaveDeepPowerDown(&_qspi);
 }
 
 uint8_t MX25R6435FClass::status(void)
 {
-  return BSP_QSPI_GetStatus();
+  return BSP_QSPI_GetStatus(&_qspi);
 }
 
 uint32_t MX25R6435FClass::info(memory_info_t info)

--- a/src/MX25R6435F.h
+++ b/src/MX25R6435F.h
@@ -39,7 +39,27 @@
 #ifndef _MX25R6435F_H_
 #define _MX25R6435F_H_
 
+#include "Arduino.h"
 #include "mx25r6435f_driver.h"
+
+#ifndef MX25R6435F_D0
+#define MX25R6435F_D0           NC
+#endif
+#ifndef MX25R6435F_D1
+#define MX25R6435F_D1           NC
+#endif
+#ifndef MX25R6435F_D2
+#define MX25R6435F_D2           NC
+#endif
+#ifndef MX25R6435F_D3
+#define MX25R6435F_D3           NC
+#endif
+#ifndef MX25R6435F_SCLK
+#define MX25R6435F_SCLK         NC
+#endif
+#ifndef MX25R6435F_SSEL
+#define MX25R6435F_SSEL         NC
+#endif
 
 /* Memory configuration paremeters */
 typedef enum {
@@ -65,8 +85,41 @@ class MX25R6435FClass
   public:
     MX25R6435FClass();
 
+    // setDx/SCLK/SSEL have to be called before begin()
+    void setDx(uint32_t data0, uint32_t data1, uint32_t data2, uint32_t data3)
+    {
+      _qspi.pin_d0 = digitalPinToPinName(data0);
+      _qspi.pin_d1 = digitalPinToPinName(data1);
+      _qspi.pin_d2 = digitalPinToPinName(data2);
+      _qspi.pin_d3 = digitalPinToPinName(data3);
+    };
+    void setSCLK(uint32_t sclk)
+    {
+      _qspi.pin_sclk = digitalPinToPinName(sclk);
+    };
+    void setSSEL(uint32_t ssel)
+    {
+      _qspi.pin_ssel = digitalPinToPinName(ssel);
+    };
+
+    void setDx(PinName data0, PinName data1, PinName data2, PinName data3)
+    {
+      _qspi.pin_d0 = (data0);
+      _qspi.pin_d1 = (data1);
+      _qspi.pin_d2 = (data2);
+      _qspi.pin_d3 = (data3);
+    };
+    void setSCLK(PinName sclk)
+    {
+      _qspi.pin_sclk = (sclk);
+    };
+    void setSSEL(PinName ssel)
+    {
+      _qspi.pin_ssel = (ssel);
+    };
+
     /* Initializes the memory interface. */
-    void begin(void);
+    void begin(uint8_t data0 = MX25R6435F_D0, uint8_t data1 = MX25R6435F_D1, uint8_t data2 = MX25R6435F_D2, uint8_t data3 = MX25R6435F_D3, uint8_t sclk = MX25R6435F_SCLK, uint8_t ssel = MX25R6435F_SSEL);
 
     /* De-Initializes the memory interface. */
     void end(void);
@@ -174,6 +227,7 @@ class MX25R6435FClass
 
   private:
     uint8_t initDone;
+    QSPI_t _qspi;
 };
 
 extern MX25R6435FClass MX25R6435F;

--- a/src/MX25R6435F.h
+++ b/src/MX25R6435F.h
@@ -23,23 +23,27 @@
 #include "Arduino.h"
 #include "mx25r6435f_driver.h"
 
+/*
+ * For backward compatibility define the xSPI pins used by:
+ * B-L475E-IOT01A and B-L4S5I-IOT01A
+ */
 #ifndef MX25R6435F_D0
-  #define MX25R6435F_D0           NC
+  #define MX25R6435F_D0           PE12
 #endif
 #ifndef MX25R6435F_D1
-  #define MX25R6435F_D1           NC
+  #define MX25R6435F_D1           PE13
 #endif
 #ifndef MX25R6435F_D2
-  #define MX25R6435F_D2           NC
+  #define MX25R6435F_D2           PE14
 #endif
 #ifndef MX25R6435F_D3
-  #define MX25R6435F_D3           NC
+  #define MX25R6435F_D3           PE15
 #endif
 #ifndef MX25R6435F_SCLK
-  #define MX25R6435F_SCLK         NC
+  #define MX25R6435F_SCLK         PE10
 #endif
 #ifndef MX25R6435F_SSEL
-  #define MX25R6435F_SSEL         NC
+  #define MX25R6435F_SSEL         PE11
 #endif
 
 /* Memory configuration paremeters */

--- a/src/MX25R6435F.h
+++ b/src/MX25R6435F.h
@@ -1,37 +1,18 @@
 /**
   ******************************************************************************
   * @file    MX25R6435F.h
-  * @author  WI6LABS
-  * @version V1.0.0
-  * @date    19-July-2017
   * @brief   MX25R6435F library for STM32 Arduino
   *
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+  * <h2><center>&copy; Copyright (c) 2020 STMicroelectronics.
+  * All rights reserved.</center></h2>
   *
-  * Redistribution and use in source and binary forms, with or without modification,
-  * are permitted provided that the following conditions are met:
-  *   1. Redistributions of source code must retain the above copyright notice,
-  *      this list of conditions and the following disclaimer.
-  *   2. Redistributions in binary form must reproduce the above copyright notice,
-  *      this list of conditions and the following disclaimer in the documentation
-  *      and/or other materials provided with the distribution.
-  *   3. Neither the name of STMicroelectronics nor the names of its contributors
-  *      may be used to endorse or promote products derived from this software
-  *      without specific prior written permission.
-  *
-  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
   *
   ******************************************************************************
   */
@@ -43,22 +24,22 @@
 #include "mx25r6435f_driver.h"
 
 #ifndef MX25R6435F_D0
-#define MX25R6435F_D0           NC
+  #define MX25R6435F_D0           NC
 #endif
 #ifndef MX25R6435F_D1
-#define MX25R6435F_D1           NC
+  #define MX25R6435F_D1           NC
 #endif
 #ifndef MX25R6435F_D2
-#define MX25R6435F_D2           NC
+  #define MX25R6435F_D2           NC
 #endif
 #ifndef MX25R6435F_D3
-#define MX25R6435F_D3           NC
+  #define MX25R6435F_D3           NC
 #endif
 #ifndef MX25R6435F_SCLK
-#define MX25R6435F_SCLK         NC
+  #define MX25R6435F_SCLK         NC
 #endif
 #ifndef MX25R6435F_SSEL
-#define MX25R6435F_SSEL         NC
+  #define MX25R6435F_SSEL         NC
 #endif
 
 /* Memory configuration paremeters */
@@ -80,8 +61,7 @@ typedef enum {
 /* Base address of the memory in mapped mode */
 #define MEMORY_MAPPED_ADDRESS ((uint32_t)0x90000000)
 
-class MX25R6435FClass
-{
+class MX25R6435FClass {
   public:
     MX25R6435FClass();
 

--- a/src/mx25r6435f_desc.h
+++ b/src/mx25r6435f_desc.h
@@ -1,77 +1,34 @@
 /**
   ******************************************************************************
   * @file    mx25r6435f.h
-  * @author  MCD Application Team
-  * @version V1.0.0
-  * @date    17-February-2017
   * @brief   This file contains all the description of the MX25R6435F QSPI memory.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+  * <h2><center>&copy; Copyright (c) 2020 STMicroelectronics.
+  * All rights reserved.</center></h2>
   *
-  * Redistribution and use in source and binary forms, with or without modification,
-  * are permitted provided that the following conditions are met:
-  *   1. Redistributions of source code must retain the above copyright notice,
-  *      this list of conditions and the following disclaimer.
-  *   2. Redistributions in binary form must reproduce the above copyright notice,
-  *      this list of conditions and the following disclaimer in the documentation
-  *      and/or other materials provided with the distribution.
-  *   3. Neither the name of STMicroelectronics nor the names of its contributors
-  *      may be used to endorse or promote products derived from this software
-  *      without specific prior written permission.
-  *
-  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
   *
   ******************************************************************************
-  */ 
+  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef __MX25R6435F_H
 #define __MX25R6435F_H
 
 #ifdef __cplusplus
- extern "C" {
-#endif 
+extern "C" {
+#endif
 
 /* Includes ------------------------------------------------------------------*/
 
-/** @addtogroup BSP
-  * @{
-  */ 
-
-/** @addtogroup Components
-  * @{
-  */ 
-  
-/** @addtogroup mx25r6435f
-  * @{
-  */
-
-/** @defgroup MX25R6435F_Exported_Types
-  * @{
-  */
-   
 /**
-  * @}
-  */ 
-
-/** @defgroup MX25R6435F_Exported_Constants
-  * @{
+  * @brief  MX25R6435F Configuration
   */
-   
-/** 
-  * @brief  MX25R6435F Configuration  
-  */  
 #define MX25R6435F_FLASH_SIZE                0x800000  /* 64 MBits => 8MBytes */
 #define MX25R6435F_BLOCK_SIZE                0x10000   /* 128 blocks of 64KBytes */
 #define MX25R6435F_SUBBLOCK_SIZE             0x8000    /* 256 blocks of 32KBytes */
@@ -92,9 +49,9 @@
 #define MX25R6435F_SUBBLOCK_ERASE_MAX_TIME   3000
 #define MX25R6435F_SECTOR_ERASE_MAX_TIME     240
 
-/** 
-  * @brief  MX25R6435F Commands  
-  */  
+/**
+  * @brief  MX25R6435F Commands
+  */
 /* Read Operations */
 #define READ_CMD                             0x03
 #define FAST_READ_CMD                        0x0B
@@ -155,9 +112,9 @@
 #define RESET_MEMORY_CMD                     0x99
 #define RELEASE_READ_ENHANCED_CMD            0xFF
 
-/** 
-  * @brief  MX25R6435F Registers  
-  */ 
+/**
+  * @brief  MX25R6435F Registers
+  */
 /* Status Register */
 #define MX25R6435F_SR_WIP                    ((uint8_t)0x01)    /*!< Write in progress */
 #define MX25R6435F_SR_WEL                    ((uint8_t)0x02)    /*!< Write enable latch */
@@ -179,29 +136,6 @@
 #define MX25R6435F_SECR_P_FAIL               ((uint8_t)0x20)    /*!< Program fail flag */
 #define MX25R6435F_SECR_E_FAIL               ((uint8_t)0x40)    /*!< Erase fail flag */
 
-/**
-  * @}
-  */
-  
-/** @defgroup MX25R6435F_Exported_Functions
-  * @{
-  */ 
-/**
-  * @}
-  */ 
-
-/**
-  * @}
-  */ 
-
-/**
-  * @}
-  */ 
-
-/**
-  * @}
-  */
-  
 #ifdef __cplusplus
 }
 #endif

--- a/src/mx25r6435f_driver.c
+++ b/src/mx25r6435f_driver.c
@@ -196,7 +196,6 @@ uint8_t BSP_QSPI_Init(QSPI_t *obj)
     return QSPI_ERROR;
   }
 
-
   handle->Instance = obj->qspi;
 
   /* Call the DeInit function to reset the driver */
@@ -322,17 +321,6 @@ uint8_t BSP_QSPI_Read(QSPI_t *obj, uint8_t* pData, uint32_t ReadAddr, uint32_t S
   sCommand.DQSMode               = HAL_OSPI_DQS_DISABLE;
   sCommand.SIOOMode              = HAL_OSPI_SIOO_INST_EVERY_CMD;
 
-  /* Configure the command */
-  if (HAL_OSPI_Command(handle, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  /* Reception of the data */
-  if (HAL_OSPI_Receive(handle, pData, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
 #else /* OCTOSPI */
   QSPI_CommandTypeDef sCommand;
 
@@ -351,19 +339,17 @@ uint8_t BSP_QSPI_Read(QSPI_t *obj, uint8_t* pData, uint32_t ReadAddr, uint32_t S
   sCommand.DdrMode            = QSPI_DDR_MODE_DISABLE;
   sCommand.DdrHoldHalfCycle   = QSPI_DDR_HHC_ANALOG_DELAY;
   sCommand.SIOOMode           = QSPI_SIOO_INST_EVERY_CMD;
+#endif /* OCTOSPI */
 
   /* Configure the command */
-  if (HAL_QSPI_Command(handle, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Command(handle, &sCommand, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
   /* Reception of the data */
-  if (HAL_QSPI_Receive(handle, pData, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Receive(handle, pData, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
-#endif /* OCTOSPI */
 
   return QSPI_OK;
 }
@@ -379,11 +365,6 @@ uint8_t BSP_QSPI_Read(QSPI_t *obj, uint8_t* pData, uint32_t ReadAddr, uint32_t S
 uint8_t BSP_QSPI_Write(QSPI_t *obj, uint8_t* pData, uint32_t WriteAddr, uint32_t Size)
 {
   XSPI_HandleTypeDef *handle = &(obj->handle);
-#ifdef OCTOSPI
-  OSPI_RegularCmdTypeDef sCommand;
-#else /* OCTOSPI */
-  QSPI_CommandTypeDef sCommand;
-#endif /* OCTOSPI */
   uint32_t end_addr, current_size, current_addr;
 
   /* Calculation of the size between the write address and the end of the page */
@@ -400,6 +381,8 @@ uint8_t BSP_QSPI_Write(QSPI_t *obj, uint8_t* pData, uint32_t WriteAddr, uint32_t
   end_addr = WriteAddr + Size;
 
 #ifdef OCTOSPI
+  OSPI_RegularCmdTypeDef sCommand;
+
   /* Initialize the program command */
   sCommand.OperationType      = HAL_OSPI_OPTYPE_COMMON_CFG;
   sCommand.FlashId            = HAL_OSPI_FLASH_ID_1;
@@ -416,38 +399,9 @@ uint8_t BSP_QSPI_Write(QSPI_t *obj, uint8_t* pData, uint32_t WriteAddr, uint32_t
   sCommand.DummyCycles        = 0;
   sCommand.DQSMode            = HAL_OSPI_DQS_DISABLE;
   sCommand.SIOOMode           = HAL_OSPI_SIOO_INST_EVERY_CMD;
-
-  /* Perform the write page by page */
-  do
-  {
-    sCommand.Address = current_addr;
-    sCommand.NbData  = current_size;
-
-    /* Enable write operations */
-    if (QSPI_WriteEnable(handle) != QSPI_OK)
-    {
-      return QSPI_ERROR;
-    }
-
-    /* Configure the command */
-    if (HAL_OSPI_Command(handle, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-    {
-      return QSPI_ERROR;
-    }
-
-    /* Transmission of the data */
-    if (HAL_OSPI_Transmit(handle, pData, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-    {
-      return QSPI_ERROR;
-    }
-
-    /* Configure automatic polling mode to wait for end of program */
-    if (QSPI_AutoPollingMemReady(handle, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != QSPI_OK)
-    {
-      return QSPI_ERROR;
-    }
-
 #else /* OCTOSPI */
+  QSPI_CommandTypeDef sCommand;
+
   /* Initialize the program command */
   sCommand.InstructionMode   = QSPI_INSTRUCTION_1_LINE;
   sCommand.Instruction       = QUAD_PAGE_PROG_CMD;
@@ -459,6 +413,7 @@ uint8_t BSP_QSPI_Write(QSPI_t *obj, uint8_t* pData, uint32_t WriteAddr, uint32_t
   sCommand.DdrMode           = QSPI_DDR_MODE_DISABLE;
   sCommand.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
   sCommand.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+#endif /* OCTOSPI */
 
   /* Perform the write page by page */
   do
@@ -467,29 +422,24 @@ uint8_t BSP_QSPI_Write(QSPI_t *obj, uint8_t* pData, uint32_t WriteAddr, uint32_t
     sCommand.NbData  = current_size;
 
     /* Enable write operations */
-    if (QSPI_WriteEnable(handle) != QSPI_OK)
-    {
+    if (QSPI_WriteEnable(handle) != QSPI_OK) {
       return QSPI_ERROR;
     }
 
     /* Configure the command */
-    if (HAL_QSPI_Command(handle, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-    {
+    if (HAL_XSPI_Command(handle, &sCommand, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
       return QSPI_ERROR;
     }
 
     /* Transmission of the data */
-    if (HAL_QSPI_Transmit(handle, pData, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-    {
+    if (HAL_XSPI_Transmit(handle, pData, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
       return QSPI_ERROR;
     }
 
     /* Configure automatic polling mode to wait for end of program */
-    if (QSPI_AutoPollingMemReady(handle, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != QSPI_OK)
-    {
+    if (QSPI_AutoPollingMemReady(handle, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != QSPI_OK) {
       return QSPI_ERROR;
     }
-#endif /* OCTOSPI */
 
     /* Update the address and size variables for next page programming */
     current_addr += current_size;
@@ -528,25 +478,6 @@ uint8_t BSP_QSPI_Erase_Block(QSPI_t *obj, uint32_t BlockAddress)
   sCommand.DummyCycles        = 0;
   sCommand.DQSMode            = HAL_OSPI_DQS_DISABLE;
   sCommand.SIOOMode           = HAL_OSPI_SIOO_INST_EVERY_CMD;
-
-  /* Enable write operations */
-  if (QSPI_WriteEnable(handle) != QSPI_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  /* Send the command */
-  if (HAL_OSPI_Command(handle, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  /* Configure automatic polling mode to wait for end of erase */
-  if (QSPI_AutoPollingMemReady(handle, MX25R6435F_BLOCK_ERASE_MAX_TIME) != QSPI_OK)
-  {
-    return QSPI_ERROR;
-  }
-
 #else /* OCTOSPI */
   QSPI_CommandTypeDef sCommand;
 
@@ -562,26 +493,22 @@ uint8_t BSP_QSPI_Erase_Block(QSPI_t *obj, uint32_t BlockAddress)
   sCommand.DdrMode           = QSPI_DDR_MODE_DISABLE;
   sCommand.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
   sCommand.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+#endif /* OCTOSPI */
 
   /* Enable write operations */
-  if (QSPI_WriteEnable(handle) != QSPI_OK)
-  {
+  if (QSPI_WriteEnable(handle) != QSPI_OK) {
     return QSPI_ERROR;
   }
 
   /* Send the command */
-  if (HAL_QSPI_Command(handle, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Command(handle, &sCommand, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
   /* Configure automatic polling mode to wait for end of erase */
-  if (QSPI_AutoPollingMemReady(handle, MX25R6435F_BLOCK_ERASE_MAX_TIME) != QSPI_OK)
-  {
+  if (QSPI_AutoPollingMemReady(handle, MX25R6435F_BLOCK_ERASE_MAX_TIME) != QSPI_OK) {
     return QSPI_ERROR;
   }
-
-#endif /* OCTOSPI */
   return QSPI_OK;
 }
 
@@ -600,13 +527,13 @@ uint8_t BSP_QSPI_Erase_Sector(QSPI_t *obj, uint32_t Sector)
 {
   XSPI_HandleTypeDef *handle = &(obj->handle);
 
-#ifdef OCTOSPI
-  OSPI_RegularCmdTypeDef sCommand;
-
   if (Sector >= (uint32_t)(MX25R6435F_FLASH_SIZE/MX25R6435F_SECTOR_SIZE))
   {
     return QSPI_ERROR;
   }
+
+#ifdef OCTOSPI
+  OSPI_RegularCmdTypeDef sCommand;
 
   /* Initialize the erase command */
   sCommand.OperationType      = HAL_OSPI_OPTYPE_COMMON_CFG;
@@ -624,25 +551,8 @@ uint8_t BSP_QSPI_Erase_Sector(QSPI_t *obj, uint32_t Sector)
   sCommand.DummyCycles        = 0;
   sCommand.DQSMode            = HAL_OSPI_DQS_DISABLE;
   sCommand.SIOOMode           = HAL_OSPI_SIOO_INST_EVERY_CMD;
-
-  /* Enable write operations */
-  if (QSPI_WriteEnable(handle) != QSPI_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  /* Send the command */
-  if (HAL_OSPI_Command(handle, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
 #else /* OCTOSPI */
   QSPI_CommandTypeDef sCommand;
-
-  if (Sector >= (uint32_t)(MX25R6435F_FLASH_SIZE/MX25R6435F_SECTOR_SIZE))
-  {
-    return QSPI_ERROR;
-  }
 
   /* Initialize the erase command */
   sCommand.InstructionMode   = QSPI_INSTRUCTION_1_LINE;
@@ -656,19 +566,17 @@ uint8_t BSP_QSPI_Erase_Sector(QSPI_t *obj, uint32_t Sector)
   sCommand.DdrMode           = QSPI_DDR_MODE_DISABLE;
   sCommand.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
   sCommand.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+#endif /* OCTOSPI */
 
   /* Enable write operations */
-  if (QSPI_WriteEnable(handle) != QSPI_OK)
-  {
+  if (QSPI_WriteEnable(handle) != QSPI_OK) {
     return QSPI_ERROR;
   }
 
   /* Send the command */
-  if (HAL_QSPI_Command(handle, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Command(handle, &sCommand, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
-#endif /* OCTOSPI */
 
   return QSPI_OK;
 }
@@ -698,25 +606,6 @@ uint8_t BSP_QSPI_Erase_Chip(QSPI_t *obj)
   sCommand.DummyCycles        = 0;
   sCommand.DQSMode            = HAL_OSPI_DQS_DISABLE;
   sCommand.SIOOMode           = HAL_OSPI_SIOO_INST_EVERY_CMD;
-
-  /* Enable write operations */
-  if (QSPI_WriteEnable(handle) != QSPI_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  /* Send the command */
-  if (HAL_OSPI_Command(handle, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  /* Configure automatic polling mode to wait for end of erase */
-  if (QSPI_AutoPollingMemReady(handle, MX25R6435F_CHIP_ERASE_MAX_TIME) != QSPI_OK)
-  {
-    return QSPI_ERROR;
-  }
-
 #else /* OCTOSPI */
   QSPI_CommandTypeDef sCommand;
 
@@ -730,25 +619,22 @@ uint8_t BSP_QSPI_Erase_Chip(QSPI_t *obj)
   sCommand.DdrMode           = QSPI_DDR_MODE_DISABLE;
   sCommand.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
   sCommand.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+#endif /* OCTOSPI */
 
   /* Enable write operations */
-  if (QSPI_WriteEnable(handle) != QSPI_OK)
-  {
+  if (QSPI_WriteEnable(handle) != QSPI_OK) {
     return QSPI_ERROR;
   }
 
   /* Send the command */
-  if (HAL_QSPI_Command(handle, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Command(handle, &sCommand, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
   /* Configure automatic polling mode to wait for end of erase */
-  if (QSPI_AutoPollingMemReady(handle, MX25R6435F_CHIP_ERASE_MAX_TIME) != QSPI_OK)
-  {
+  if (QSPI_AutoPollingMemReady(handle, MX25R6435F_CHIP_ERASE_MAX_TIME) != QSPI_OK) {
     return QSPI_ERROR;
   }
-#endif /* OCTOSPI */
 
   return QSPI_OK;
 }
@@ -780,43 +666,6 @@ uint8_t BSP_QSPI_GetStatus(QSPI_t *obj)
   sCommand.DummyCycles        = 0;
   sCommand.DQSMode            = HAL_OSPI_DQS_DISABLE;
   sCommand.SIOOMode           = HAL_OSPI_SIOO_INST_EVERY_CMD;
-
-  /* Configure the command */
-  if (HAL_OSPI_Command(handle, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  /* Reception of the data */
-  if (HAL_OSPI_Receive(handle, &reg, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  /* Check the value of the register */
-  if ((reg & (MX25R6435F_SECR_P_FAIL | MX25R6435F_SECR_E_FAIL)) != 0)
-  {
-    return QSPI_ERROR;
-  }
-  else if ((reg & (MX25R6435F_SECR_PSB | MX25R6435F_SECR_ESB)) != 0)
-  {
-    return QSPI_SUSPENDED;
-  }
-
-  /* Initialize the read status register command */
-  sCommand.Instruction = READ_STATUS_REG_CMD;
-
-  /* Configure the command */
-  if (HAL_OSPI_Command(handle, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  /* Reception of the data */
-  if (HAL_OSPI_Receive(handle, &reg, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
 #else /* OCTOSPI */
   QSPI_CommandTypeDef sCommand;
 
@@ -831,52 +680,43 @@ uint8_t BSP_QSPI_GetStatus(QSPI_t *obj)
   sCommand.DdrMode           = QSPI_DDR_MODE_DISABLE;
   sCommand.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
   sCommand.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+#endif /* OCTOSPI */
 
   /* Configure the command */
-  if (HAL_QSPI_Command(handle, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Command(handle, &sCommand, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
   /* Reception of the data */
-  if (HAL_QSPI_Receive(handle, &reg, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Receive(handle, &reg, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
   /* Check the value of the register */
-  if ((reg & (MX25R6435F_SECR_P_FAIL | MX25R6435F_SECR_E_FAIL)) != 0)
-  {
+  if ((reg & (MX25R6435F_SECR_P_FAIL | MX25R6435F_SECR_E_FAIL)) != 0) {
     return QSPI_ERROR;
   }
-  else if ((reg & (MX25R6435F_SECR_PSB | MX25R6435F_SECR_ESB)) != 0)
-  {
+  else if ((reg & (MX25R6435F_SECR_PSB | MX25R6435F_SECR_ESB)) != 0) {
     return QSPI_SUSPENDED;
   }
 
   /* Initialize the read status register command */
-  sCommand.Instruction       = READ_STATUS_REG_CMD;
+  sCommand.Instruction = READ_STATUS_REG_CMD;
 
   /* Configure the command */
-  if (HAL_QSPI_Command(handle, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Command(handle, &sCommand, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
   /* Reception of the data */
-  if (HAL_QSPI_Receive(handle, &reg, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Receive(handle, &reg, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
-#endif /* OCTOSPI */
 
   /* Check the value of the register */
-  if ((reg & MX25R6435F_SR_WIP) != 0)
-  {
+  if ((reg & MX25R6435F_SR_WIP) != 0) {
     return QSPI_BUSY;
-  }
-  else
-  {
+  } else {
     return QSPI_OK;
   }
 }
@@ -932,8 +772,7 @@ uint8_t BSP_QSPI_EnableMemoryMappedMode(QSPI_t *obj)
   sCommand.SIOOMode              = HAL_OSPI_SIOO_INST_EVERY_CMD;
 
   /* Configure the command */
-  if (HAL_OSPI_Command(handle, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_OSPI_Command(handle, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
@@ -944,16 +783,14 @@ uint8_t BSP_QSPI_EnableMemoryMappedMode(QSPI_t *obj)
   sCommand.DummyCycles        = 0;
 
   /* Configure the command */
-  if (HAL_OSPI_Command(handle, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_OSPI_Command(handle, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
   /* Configure the memory mapped mode */
   sMemMappedCfg.TimeOutActivation = HAL_OSPI_TIMEOUT_COUNTER_DISABLE;
 
-  if (HAL_OSPI_MemoryMapped(handle, &sMemMappedCfg) != HAL_OK)
-  {
+  if (HAL_OSPI_MemoryMapped(handle, &sMemMappedCfg) != HAL_OK) {
     return QSPI_ERROR;
   }
 #else /* OCTOSPI */
@@ -977,8 +814,7 @@ uint8_t BSP_QSPI_EnableMemoryMappedMode(QSPI_t *obj)
   /* Configure the memory mapped mode */
   sMemMappedCfg.TimeOutActivation = QSPI_TIMEOUT_COUNTER_DISABLE;
 
-  if (HAL_QSPI_MemoryMapped(handle, &sCommand, &sMemMappedCfg) != HAL_OK)
-  {
+  if (HAL_QSPI_MemoryMapped(handle, &sCommand, &sMemMappedCfg) != HAL_OK) {
     return QSPI_ERROR;
   }
 #endif /* OCTOSPI */
@@ -995,14 +831,14 @@ uint8_t BSP_QSPI_SuspendErase(QSPI_t *obj)
 {
   XSPI_HandleTypeDef *handle = &(obj->handle);
 
-#ifdef OCTOSPI
-  OSPI_RegularCmdTypeDef sCommand;
-
   /* Check whether the device is busy (erase operation is
   in progress).
   */
   if (BSP_QSPI_GetStatus(obj) == QSPI_BUSY)
   {
+#ifdef OCTOSPI
+    OSPI_RegularCmdTypeDef sCommand;
+
     /* Initialize the suspend command */
     sCommand.OperationType      = HAL_OSPI_OPTYPE_COMMON_CFG;
     sCommand.FlashId            = HAL_OSPI_FLASH_ID_1;
@@ -1016,20 +852,9 @@ uint8_t BSP_QSPI_SuspendErase(QSPI_t *obj)
     sCommand.DummyCycles        = 0;
     sCommand.DQSMode            = HAL_OSPI_DQS_DISABLE;
     sCommand.SIOOMode           = HAL_OSPI_SIOO_INST_EVERY_CMD;
+#else /* OCTOSPI */
+    QSPI_CommandTypeDef sCommand;
 
-    /* Send the command */
-    if (HAL_OSPI_Command(handle, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-    {
-      return QSPI_ERROR;
-    }
- #else /* OCTOSPI */
-  QSPI_CommandTypeDef sCommand;
-
-  /* Check whether the device is busy (erase operation is
-  in progress).
-  */
-  if (BSP_QSPI_GetStatus() == QSPI_BUSY)
-  {
     /* Initialize the erase command */
     sCommand.InstructionMode   = QSPI_INSTRUCTION_1_LINE;
     sCommand.Instruction       = PROG_ERASE_SUSPEND_CMD;
@@ -1040,16 +865,13 @@ uint8_t BSP_QSPI_SuspendErase(QSPI_t *obj)
     sCommand.DdrMode           = QSPI_DDR_MODE_DISABLE;
     sCommand.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
     sCommand.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
-
+#endif /* OCTOSPI */
     /* Send the command */
-    if (HAL_QSPI_Command(handle, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-    {
+    if (HAL_XSPI_Command(handle, &sCommand, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
       return QSPI_ERROR;
     }
-#endif /* OCTOSPI */
 
-    if (BSP_QSPI_GetStatus(obj) == QSPI_SUSPENDED)
-    {
+    if (BSP_QSPI_GetStatus(obj) == QSPI_SUSPENDED) {
       return QSPI_OK;
     }
 
@@ -1068,12 +890,12 @@ uint8_t BSP_QSPI_ResumeErase(QSPI_t *obj)
 {
   XSPI_HandleTypeDef *handle = &(obj->handle);
 
-#ifdef OCTOSPI
-  OSPI_RegularCmdTypeDef sCommand;
-
   /* Check whether the device is in suspended state */
   if (BSP_QSPI_GetStatus(obj) == QSPI_SUSPENDED)
   {
+#ifdef OCTOSPI
+    OSPI_RegularCmdTypeDef sCommand;
+
     /* Initialize the resume command */
     sCommand.OperationType      = HAL_OSPI_OPTYPE_COMMON_CFG;
     sCommand.FlashId            = HAL_OSPI_FLASH_ID_1;
@@ -1087,19 +909,9 @@ uint8_t BSP_QSPI_ResumeErase(QSPI_t *obj)
     sCommand.DummyCycles        = 0;
     sCommand.DQSMode            = HAL_OSPI_DQS_DISABLE;
     sCommand.SIOOMode           = HAL_OSPI_SIOO_INST_EVERY_CMD;
-
-    /* Send the command */
-    if (HAL_OSPI_Command(handle, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-    {
-      return QSPI_ERROR;
-    }
-
 #else /* OCTOSPI */
-  QSPI_CommandTypeDef sCommand;
+    QSPI_CommandTypeDef sCommand;
 
-  /* Check whether the device is in suspended state */
-  if (BSP_QSPI_GetStatus() == QSPI_SUSPENDED)
-  {
     /* Initialize the erase command */
     sCommand.InstructionMode   = QSPI_INSTRUCTION_1_LINE;
     sCommand.Instruction       = PROG_ERASE_RESUME_CMD;
@@ -1110,23 +922,18 @@ uint8_t BSP_QSPI_ResumeErase(QSPI_t *obj)
     sCommand.DdrMode           = QSPI_DDR_MODE_DISABLE;
     sCommand.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
     sCommand.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
-
+#endif /* OCTOSPI */
     /* Send the command */
-    if (HAL_QSPI_Command(handle, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-    {
+    if (HAL_XSPI_Command(handle, &sCommand, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
       return QSPI_ERROR;
     }
-
-#endif /* OCTOSPI */
-
     /*
     When this command is executed, the status register write in progress bit is set to 1, and
     the flag status register program erase controller bit is set to 0. This command is ignored
     if the device is not in a suspended state.
     */
 
-    if (BSP_QSPI_GetStatus(obj) == QSPI_BUSY)
-    {
+    if (BSP_QSPI_GetStatus(obj) == QSPI_BUSY) {
       return QSPI_OK;
     }
 
@@ -1161,12 +968,6 @@ uint8_t BSP_QSPI_EnterDeepPowerDown(QSPI_t *obj)
   sCommand.DummyCycles        = 0;
   sCommand.DQSMode            = HAL_OSPI_DQS_DISABLE;
   sCommand.SIOOMode           = HAL_OSPI_SIOO_INST_EVERY_CMD;
-
-  /* Send the command */
-  if (HAL_OSPI_Command(handle, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
 #else /* OCTOSPI */
   QSPI_CommandTypeDef sCommand;
 
@@ -1180,13 +981,12 @@ uint8_t BSP_QSPI_EnterDeepPowerDown(QSPI_t *obj)
   sCommand.DdrMode           = QSPI_DDR_MODE_DISABLE;
   sCommand.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
   sCommand.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+#endif /* OCTOSPI */
 
   /* Send the command */
-  if (HAL_QSPI_Command(handle, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Command(handle, &sCommand, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
-#endif /* OCTOSPI */
 
   /* ---          Memory takes 10us max to enter deep power down          --- */
   /* --- At least 30us should be respected before leaving deep power down --- */
@@ -1219,13 +1019,6 @@ uint8_t BSP_QSPI_LeaveDeepPowerDown(QSPI_t *obj)
   sCommand.DummyCycles        = 0;
   sCommand.DQSMode            = HAL_OSPI_DQS_DISABLE;
   sCommand.SIOOMode           = HAL_OSPI_SIOO_INST_EVERY_CMD;
-
-  /* Send the command */
-  if (HAL_OSPI_Command(handle, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
-
 #else /* OCTOSPI */
   QSPI_CommandTypeDef sCommand;
 
@@ -1239,13 +1032,12 @@ uint8_t BSP_QSPI_LeaveDeepPowerDown(QSPI_t *obj)
   sCommand.DdrMode           = QSPI_DDR_MODE_DISABLE;
   sCommand.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
   sCommand.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+#endif /* OCTOSPI */
 
   /* Send the command */
-  if (HAL_QSPI_Command(handle, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Command(handle, &sCommand, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
-#endif /* OCTOSPI */
 
   /* --- A NOP command is sent to the memory, as the nCS should be low for at least 20 ns --- */
   /* ---                  Memory takes 35us min to leave deep power down                  --- */
@@ -1374,26 +1166,6 @@ static uint8_t QSPI_ResetMemory(XSPI_HandleTypeDef *hxspi)
   sCommand.DummyCycles        = 0;
   sCommand.DQSMode            = HAL_OSPI_DQS_DISABLE;
   sCommand.SIOOMode           = HAL_OSPI_SIOO_INST_EVERY_CMD;
-
-  /* Send the command */
-  if (HAL_OSPI_Command(hxspi, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  /* Send the reset memory command */
-  sCommand.Instruction = RESET_MEMORY_CMD;
-  if (HAL_OSPI_Command(hxspi, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  /* Configure automatic polling mode to wait the memory is ready */
-  if (QSPI_AutoPollingMemReady(hxspi, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != QSPI_OK)
-  {
-    return QSPI_ERROR;
-  }
-
 #else /* OCTOSPI */
   QSPI_CommandTypeDef sCommand;
 
@@ -1407,26 +1179,23 @@ static uint8_t QSPI_ResetMemory(XSPI_HandleTypeDef *hxspi)
   sCommand.DdrMode           = QSPI_DDR_MODE_DISABLE;
   sCommand.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
   sCommand.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+#endif /* OCTOSPI */
 
   /* Send the command */
-  if (HAL_QSPI_Command(hxspi, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Command(hxspi, &sCommand, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
   /* Send the reset memory command */
   sCommand.Instruction = RESET_MEMORY_CMD;
-  if (HAL_QSPI_Command(hxspi, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Command(hxspi, &sCommand, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
   /* Configure automatic polling mode to wait the memory is ready */
-  if (QSPI_AutoPollingMemReady(hxspi, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != QSPI_OK)
-  {
+  if (QSPI_AutoPollingMemReady(hxspi, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != QSPI_OK) {
     return QSPI_ERROR;
   }
-#endif /* OCTOSPI */
 
   return QSPI_OK;
 }
@@ -1456,8 +1225,7 @@ static uint8_t QSPI_WriteEnable(XSPI_HandleTypeDef *hxspi)
   sCommand.DQSMode            = HAL_OSPI_DQS_DISABLE;
   sCommand.SIOOMode           = HAL_OSPI_SIOO_INST_EVERY_CMD;
 
-  if (HAL_OSPI_Command(hxspi, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_OSPI_Command(hxspi, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
@@ -1473,13 +1241,11 @@ static uint8_t QSPI_WriteEnable(XSPI_HandleTypeDef *hxspi)
   sCommand.NbData       = 1;
   sCommand.DataDtrMode  = HAL_OSPI_DATA_DTR_DISABLE;
 
-  if (HAL_OSPI_Command(hxspi, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_OSPI_Command(hxspi, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
-  if (HAL_OSPI_AutoPolling(hxspi, &sConfig, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_OSPI_AutoPolling(hxspi, &sConfig, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 #else /* OCTOSPI */
@@ -1497,8 +1263,7 @@ static uint8_t QSPI_WriteEnable(XSPI_HandleTypeDef *hxspi)
   sCommand.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
   sCommand.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
 
-  if (HAL_QSPI_Command(hxspi, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_QSPI_Command(hxspi, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
@@ -1513,8 +1278,7 @@ static uint8_t QSPI_WriteEnable(XSPI_HandleTypeDef *hxspi)
   sCommand.Instruction    = READ_STATUS_REG_CMD;
   sCommand.DataMode       = QSPI_DATA_1_LINE;
 
-  if (HAL_QSPI_AutoPolling(hxspi, &sCommand, &sConfig, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_QSPI_AutoPolling(hxspi, &sCommand, &sConfig, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 #endif /* OCTOSPI */
@@ -1556,13 +1320,11 @@ static uint8_t QSPI_AutoPollingMemReady(XSPI_HandleTypeDef *hxspi, uint32_t Time
   sConfig.Interval      = 0x10;
   sConfig.AutomaticStop = HAL_OSPI_AUTOMATIC_STOP_ENABLE;
 
-  if (HAL_OSPI_Command(hxspi, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_OSPI_Command(hxspi, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
-  if (HAL_OSPI_AutoPolling(hxspi, &sConfig, Timeout) != HAL_OK)
-  {
+  if (HAL_OSPI_AutoPolling(hxspi, &sConfig, Timeout) != HAL_OK) {
     return QSPI_ERROR;
   }
 #else /* OCTOSPI */
@@ -1587,8 +1349,7 @@ static uint8_t QSPI_AutoPollingMemReady(XSPI_HandleTypeDef *hxspi, uint32_t Time
   sConfig.Interval        = 0x10;
   sConfig.AutomaticStop   = QSPI_AUTOMATIC_STOP_ENABLE;
 
-  if (HAL_QSPI_AutoPolling(hxspi, &sCommand, &sConfig, Timeout) != HAL_OK)
-  {
+  if (HAL_QSPI_AutoPolling(hxspi, &sCommand, &sConfig, Timeout) != HAL_OK) {
     return QSPI_ERROR;
   }
 #endif /* OCTOSPI */
@@ -1604,9 +1365,9 @@ static uint8_t QSPI_AutoPollingMemReady(XSPI_HandleTypeDef *hxspi, uint32_t Time
   */
 static uint8_t QSPI_QuadMode(XSPI_HandleTypeDef *hxspi, uint8_t Operation)
 {
+  uint8_t reg;
 #ifdef OCTOSPI
   OSPI_RegularCmdTypeDef sCommand;
-  uint8_t reg;
 
   /* Read status register */
   sCommand.OperationType      = HAL_OSPI_OPTYPE_COMMON_CFG;
@@ -1623,66 +1384,8 @@ static uint8_t QSPI_QuadMode(XSPI_HandleTypeDef *hxspi, uint8_t Operation)
   sCommand.NbData             = 1;
   sCommand.DQSMode            = HAL_OSPI_DQS_DISABLE;
   sCommand.SIOOMode           = HAL_OSPI_SIOO_INST_EVERY_CMD;
-
-  if (HAL_OSPI_Command(hxspi, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  if (HAL_OSPI_Receive(hxspi, &reg, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  /* Enable write operations */
-  if (QSPI_WriteEnable(hxspi) != QSPI_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  /* Activate/deactivate the Quad mode */
-  if (Operation == QSPI_QUAD_ENABLE)
-  {
-    SET_BIT(reg, MX25R6435F_SR_QE);
-  }
-  else
-  {
-    CLEAR_BIT(reg, MX25R6435F_SR_QE);
-  }
-
-  sCommand.Instruction = WRITE_STATUS_CFG_REG_CMD;
-
-  if (HAL_OSPI_Command(hxspi, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  if (HAL_OSPI_Transmit(hxspi, &reg, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  /* Wait that memory is ready */
-  if (QSPI_AutoPollingMemReady(hxspi, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != QSPI_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  /* Check the configuration has been correctly done */
-  sCommand.Instruction = READ_STATUS_REG_CMD;
-
-  if (HAL_OSPI_Command(hxspi, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  if (HAL_OSPI_Receive(hxspi, &reg, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
 #else /* OCTOSPI */
   QSPI_CommandTypeDef sCommand;
-  uint8_t reg;
 
   /* Read status register */
   sCommand.InstructionMode   = QSPI_INSTRUCTION_1_LINE;
@@ -1695,68 +1398,56 @@ static uint8_t QSPI_QuadMode(XSPI_HandleTypeDef *hxspi, uint8_t Operation)
   sCommand.DdrMode           = QSPI_DDR_MODE_DISABLE;
   sCommand.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
   sCommand.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+#endif /* OCTOSPI */
 
-  if (HAL_QSPI_Command(hxspi, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Command(hxspi, &sCommand, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
-  if (HAL_QSPI_Receive(hxspi, &reg, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Receive(hxspi, &reg, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
   /* Enable write operations */
-  if (QSPI_WriteEnable(hxspi) != QSPI_OK)
-  {
+  if (QSPI_WriteEnable(hxspi) != QSPI_OK) {
     return QSPI_ERROR;
   }
 
   /* Activate/deactivate the Quad mode */
-  if (Operation == QSPI_QUAD_ENABLE)
-  {
+  if (Operation == QSPI_QUAD_ENABLE) {
     SET_BIT(reg, MX25R6435F_SR_QE);
-  }
-  else
-  {
+  } else {
     CLEAR_BIT(reg, MX25R6435F_SR_QE);
   }
 
   sCommand.Instruction = WRITE_STATUS_CFG_REG_CMD;
 
-  if (HAL_QSPI_Command(hxspi, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Command(hxspi, &sCommand, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
-  if (HAL_QSPI_Transmit(hxspi, &reg, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Transmit(hxspi, &reg, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
   /* Wait that memory is ready */
-  if (QSPI_AutoPollingMemReady(hxspi, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != QSPI_OK)
-  {
+  if (QSPI_AutoPollingMemReady(hxspi, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != QSPI_OK) {
     return QSPI_ERROR;
   }
 
   /* Check the configuration has been correctly done */
   sCommand.Instruction = READ_STATUS_REG_CMD;
 
-  if (HAL_QSPI_Command(hxspi, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Command(hxspi, &sCommand, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
-  if (HAL_QSPI_Receive(hxspi, &reg, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Receive(hxspi, &reg, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
-#endif /* OCTOSPI */
 
   if ((((reg & MX25R6435F_SR_QE) == 0) && (Operation == QSPI_QUAD_ENABLE)) ||
-      (((reg & MX25R6435F_SR_QE) != 0) && (Operation == QSPI_QUAD_DISABLE)))
-  {
+      (((reg & MX25R6435F_SR_QE) != 0) && (Operation == QSPI_QUAD_DISABLE))) {
     return QSPI_ERROR;
   }
 
@@ -1771,9 +1462,9 @@ static uint8_t QSPI_QuadMode(XSPI_HandleTypeDef *hxspi, uint8_t Operation)
   */
 static uint8_t QSPI_HighPerfMode(XSPI_HandleTypeDef *hxspi, uint8_t Operation)
 {
+  uint8_t reg[3];
 #ifdef OCTOSPI
   OSPI_RegularCmdTypeDef sCommand;
-  uint8_t reg[3];
 
   /* Read status register */
   sCommand.OperationType      = HAL_OSPI_OPTYPE_COMMON_CFG;
@@ -1790,82 +1481,8 @@ static uint8_t QSPI_HighPerfMode(XSPI_HandleTypeDef *hxspi, uint8_t Operation)
   sCommand.NbData             = 1;
   sCommand.DQSMode            = HAL_OSPI_DQS_DISABLE;
   sCommand.SIOOMode           = HAL_OSPI_SIOO_INST_EVERY_CMD;
-
-  if (HAL_OSPI_Command(hxspi, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  if (HAL_OSPI_Receive(hxspi, &(reg[0]), HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  /* Read configuration registers */
-  sCommand.Instruction = READ_CFG_REG_CMD;
-  sCommand.NbData      = 2;
-
-  if (HAL_OSPI_Command(hxspi, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  if (HAL_OSPI_Receive(hxspi, &(reg[1]), HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  /* Enable write operations */
-  if (QSPI_WriteEnable(hxspi) != QSPI_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  /* Activate/deactivate the Quad mode */
-  if (Operation == QSPI_HIGH_PERF_ENABLE)
-  {
-    SET_BIT(reg[2], MX25R6435F_CR2_LH_SWITCH);
-  }
-  else
-  {
-    CLEAR_BIT(reg[2], MX25R6435F_CR2_LH_SWITCH);
-  }
-
-  sCommand.Instruction = WRITE_STATUS_CFG_REG_CMD;
-  sCommand.NbData      = 3;
-
-  if (HAL_OSPI_Command(hxspi, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  if (HAL_OSPI_Transmit(hxspi, &(reg[0]), HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  /* Wait that memory is ready */
-  if (QSPI_AutoPollingMemReady(hxspi, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != QSPI_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  /* Check the configuration has been correctly done */
-  sCommand.Instruction = READ_CFG_REG_CMD;
-  sCommand.NbData      = 2;
-
-  if (HAL_OSPI_Command(hxspi, &sCommand, HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
-
-  if (HAL_OSPI_Receive(hxspi, &(reg[0]), HAL_OSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
-    return QSPI_ERROR;
-  }
 #else /* OCTOSPI */
   QSPI_CommandTypeDef sCommand;
-  uint8_t reg[3];
 
   /* Read status register */
   sCommand.InstructionMode   = QSPI_INSTRUCTION_1_LINE;
@@ -1878,14 +1495,13 @@ static uint8_t QSPI_HighPerfMode(XSPI_HandleTypeDef *hxspi, uint8_t Operation)
   sCommand.DdrMode           = QSPI_DDR_MODE_DISABLE;
   sCommand.DdrHoldHalfCycle  = QSPI_DDR_HHC_ANALOG_DELAY;
   sCommand.SIOOMode          = QSPI_SIOO_INST_EVERY_CMD;
+#endif /* OCTOSPI */
 
-  if (HAL_QSPI_Command(hxspi, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Command(hxspi, &sCommand, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
-  if (HAL_QSPI_Receive(hxspi, &(reg[0]), HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Receive(hxspi, &(reg[0]), HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
@@ -1893,48 +1509,39 @@ static uint8_t QSPI_HighPerfMode(XSPI_HandleTypeDef *hxspi, uint8_t Operation)
   sCommand.Instruction = READ_CFG_REG_CMD;
   sCommand.NbData      = 2;
 
-  if (HAL_QSPI_Command(hxspi, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Command(hxspi, &sCommand, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
-  if (HAL_QSPI_Receive(hxspi, &(reg[1]), HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Receive(hxspi, &(reg[1]), HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
   /* Enable write operations */
-  if (QSPI_WriteEnable(hxspi) != QSPI_OK)
-  {
+  if (QSPI_WriteEnable(hxspi) != QSPI_OK) {
     return QSPI_ERROR;
   }
 
   /* Activate/deactivate the Quad mode */
-  if (Operation == QSPI_HIGH_PERF_ENABLE)
-  {
+  if (Operation == QSPI_HIGH_PERF_ENABLE) {
     SET_BIT(reg[2], MX25R6435F_CR2_LH_SWITCH);
-  }
-  else
-  {
+  } else {
     CLEAR_BIT(reg[2], MX25R6435F_CR2_LH_SWITCH);
   }
 
   sCommand.Instruction = WRITE_STATUS_CFG_REG_CMD;
   sCommand.NbData      = 3;
 
-  if (HAL_QSPI_Command(hxspi, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Command(hxspi, &sCommand, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
-  if (HAL_QSPI_Transmit(hxspi, &(reg[0]), HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Transmit(hxspi, &(reg[0]), HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
   /* Wait that memory is ready */
-  if (QSPI_AutoPollingMemReady(hxspi, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != QSPI_OK)
-  {
+  if (QSPI_AutoPollingMemReady(hxspi, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != QSPI_OK) {
     return QSPI_ERROR;
   }
 
@@ -1942,20 +1549,16 @@ static uint8_t QSPI_HighPerfMode(XSPI_HandleTypeDef *hxspi, uint8_t Operation)
   sCommand.Instruction = READ_CFG_REG_CMD;
   sCommand.NbData      = 2;
 
-  if (HAL_QSPI_Command(hxspi, &sCommand, HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Command(hxspi, &sCommand, HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
 
-  if (HAL_QSPI_Receive(hxspi, &(reg[0]), HAL_QPSI_TIMEOUT_DEFAULT_VALUE) != HAL_OK)
-  {
+  if (HAL_XSPI_Receive(hxspi, &(reg[0]), HAL_XSPI_TIMEOUT_DEFAULT_VALUE) != HAL_OK) {
     return QSPI_ERROR;
   }
-#endif /* OCTOSPI */
 
   if ((((reg[1] & MX25R6435F_CR2_LH_SWITCH) == 0) && (Operation == QSPI_HIGH_PERF_ENABLE)) ||
-      (((reg[1] & MX25R6435F_CR2_LH_SWITCH) != 0) && (Operation == QSPI_HIGH_PERF_DISABLE)))
-  {
+      (((reg[1] & MX25R6435F_CR2_LH_SWITCH) != 0) && (Operation == QSPI_HIGH_PERF_DISABLE))) {
     return QSPI_ERROR;
   }
 

--- a/src/mx25r6435f_driver.c
+++ b/src/mx25r6435f_driver.c
@@ -1,156 +1,60 @@
 /**
   ******************************************************************************
   * @file    mx25r6435f_driver.c
-  * @author  MCD Application Team
-  * @version V1.1.0
-  * @date    21-April-2017
   * @brief   This file includes a standard driver for the MX25R6435F QSPI
   *          memory.
-  @verbatim
-  ==============================================================================
-                     ##### How to use this driver #####
-  ==============================================================================
-  [..]
-   (#) This driver is used to drive the MX25R6435F QSPI external
-       memory mounted on STM32L475E IOT01 board.
-
-   (#) This driver need a specific component driver (MX25R6435F) to be included with.
-
-   (#) Initialization steps:
-       (++) Initialize the QPSI external memory using the BSP_QSPI_Init() function. This
-            function includes the MSP layer hardware resources initialization and the
-            QSPI interface with the external memory. The BSP_QSPI_DeInit() can be used
-            to deactivate the QSPI interface.
-
-   (#) QSPI memory operations
-       (++) QSPI memory can be accessed with read/write operations once it is
-            initialized.
-            Read/write operation can be performed with AHB access using the functions
-            BSP_QSPI_Read()/BSP_QSPI_Write().
-       (++) The function to the QSPI memory in memory-mapped mode is possible after
-            the call of the function BSP_QSPI_EnableMemoryMappedMode().
-       (++) The function BSP_QSPI_GetInfo() returns the configuration of the QSPI memory.
-            (see the QSPI memory data sheet)
-       (++) Perform erase block operation using the function BSP_QSPI_Erase_Block() and by
-            specifying the block address. You can perform an erase operation of the whole
-            chip by calling the function BSP_QSPI_Erase_Chip().
-       (++) The function BSP_QSPI_GetStatus() returns the current status of the QSPI memory.
-            (see the QSPI memory data sheet)
-       (++) Perform erase sector operation using the function BSP_QSPI_Erase_Sector()
-            which is not blocking. So the function BSP_QSPI_GetStatus() should be used
-            to check if the memory is busy, and the functions BSP_QSPI_SuspendErase()/
-            BSP_QSPI_ResumeErase() can be used to perform other operations during the
-            sector erase.
-       (++) Deep power down of the QSPI memory is managed with the call of the functions
-            BSP_QSPI_EnterDeepPowerDown()/BSP_QSPI_LeaveDeepPowerDown()
-  @endverbatim
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+  * <h2><center>&copy; Copyright (c) 2020 STMicroelectronics.
+  * All rights reserved.</center></h2>
   *
-  * Redistribution and use in source and binary forms, with or without modification,
-  * are permitted provided that the following conditions are met:
-  *   1. Redistributions of source code must retain the above copyright notice,
-  *      this list of conditions and the following disclaimer.
-  *   2. Redistributions in binary form must reproduce the above copyright notice,
-  *      this list of conditions and the following disclaimer in the documentation
-  *      and/or other materials provided with the distribution.
-  *   3. Neither the name of STMicroelectronics nor the names of its contributors
-  *      may be used to endorse or promote products derived from this software
-  *      without specific prior written permission.
-  *
-  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
   *
   ******************************************************************************
   */
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
 #include "core_debug.h"
 #include "mx25r6435f_driver.h"
 
-/** @addtogroup BSP
-  * @{
-  */
-
-/** @addtogroup STM32L475E_IOT01
-  * @{
-  */
-
-/** @defgroup STM32L475E_IOT01_QSPI QSPI
-  * @{
-  */
-
 /* Private constants --------------------------------------------------------*/
-/** @defgroup STM32L475E_IOT01_QSPI_Private_Constants QSPI Private Constants
-  * @{
-  */
 #define QSPI_QUAD_DISABLE       0x0
 #define QSPI_QUAD_ENABLE        0x1
 
 #define QSPI_HIGH_PERF_DISABLE  0x0
 #define QSPI_HIGH_PERF_ENABLE   0x1
-/**
-  * @}
-  */
-/* Private variables ---------------------------------------------------------*/
-
-/** @defgroup STM32L475E_IOT01_QSPI_Private_Variables QSPI Private Variables
-  * @{
-  */
-
-/**
-  * @}
-  */
-
 
 /* Private functions ---------------------------------------------------------*/
-
-/** @defgroup STM32L475E_IOT01_QSPI_Private_Functions QSPI Private Functions
-  * @{
-  */
-static uint8_t QSPI_ResetMemory        (XSPI_HandleTypeDef *hxspi);
-static uint8_t QSPI_WriteEnable        (XSPI_HandleTypeDef *hxspi);
+static uint8_t QSPI_ResetMemory(XSPI_HandleTypeDef *hxspi);
+static uint8_t QSPI_WriteEnable(XSPI_HandleTypeDef *hxspi);
 static uint8_t QSPI_AutoPollingMemReady(XSPI_HandleTypeDef *hxspi, uint32_t Timeout);
-static uint8_t QSPI_QuadMode           (XSPI_HandleTypeDef *hxspi, uint8_t Operation);
-static uint8_t QSPI_HighPerfMode       (XSPI_HandleTypeDef *hxspi, uint8_t Operation);
-static uint8_t qspi_setClockPrescaler  (void);
-
-/**
-  * @}
-  */
+static uint8_t QSPI_QuadMode(XSPI_HandleTypeDef *hxspi, uint8_t Operation);
+static uint8_t QSPI_HighPerfMode(XSPI_HandleTypeDef *hxspi, uint8_t Operation);
+static uint8_t qspi_setClockPrescaler(void);
 
 /* Exported functions ---------------------------------------------------------*/
-
-/** @addtogroup STM32L475E_IOT01_QSPI_Exported_Functions
-  * @{
-  */
-
 /**
   * @brief  Select a prescaler to have a clock frequency lower than the maximum.
   *         The MX25R6435F supports a maximum frequency of 80MHz.
   *         QSPI clock is connected to AHB bus clock.
   * @retval Clock prescaler. 0 means error.
   */
-static uint8_t qspi_setClockPrescaler(void) {
+static uint8_t qspi_setClockPrescaler(void)
+{
   uint8_t i;
 
-  for(i = 1; i < 255; i++) {
-    if((HAL_RCC_GetHCLKFreq() / i) <= 80000000)
+  for (i = 1; i < 255; i++) {
+    if ((HAL_RCC_GetHCLKFreq() / i) <= 80000000) {
       return i;
+    }
   }
 
   return 0;
@@ -293,7 +197,7 @@ uint8_t BSP_QSPI_DeInit(QSPI_t *obj)
   * @param  Size     : Size of data to read
   * @retval QSPI memory status
   */
-uint8_t BSP_QSPI_Read(QSPI_t *obj, uint8_t* pData, uint32_t ReadAddr, uint32_t Size)
+uint8_t BSP_QSPI_Read(QSPI_t *obj, uint8_t *pData, uint32_t ReadAddr, uint32_t Size)
 {
   XSPI_HandleTypeDef *handle = &(obj->handle);
 #ifdef OCTOSPI
@@ -362,7 +266,7 @@ uint8_t BSP_QSPI_Read(QSPI_t *obj, uint8_t* pData, uint32_t ReadAddr, uint32_t S
   * @param  Size      : Size of data to write
   * @retval QSPI memory status
   */
-uint8_t BSP_QSPI_Write(QSPI_t *obj, uint8_t* pData, uint32_t WriteAddr, uint32_t Size)
+uint8_t BSP_QSPI_Write(QSPI_t *obj, uint8_t *pData, uint32_t WriteAddr, uint32_t Size)
 {
   XSPI_HandleTypeDef *handle = &(obj->handle);
   uint32_t end_addr, current_size, current_addr;
@@ -371,8 +275,7 @@ uint8_t BSP_QSPI_Write(QSPI_t *obj, uint8_t* pData, uint32_t WriteAddr, uint32_t
   current_size = MX25R6435F_PAGE_SIZE - (WriteAddr % MX25R6435F_PAGE_SIZE);
 
   /* Check if the size of the data is less than the remaining place in the page */
-  if (current_size > Size)
-  {
+  if (current_size > Size) {
     current_size = Size;
   }
 
@@ -416,8 +319,7 @@ uint8_t BSP_QSPI_Write(QSPI_t *obj, uint8_t* pData, uint32_t WriteAddr, uint32_t
 #endif /* OCTOSPI */
 
   /* Perform the write page by page */
-  do
-  {
+  do {
     sCommand.Address = current_addr;
     sCommand.NbData  = current_size;
 
@@ -527,8 +429,7 @@ uint8_t BSP_QSPI_Erase_Sector(QSPI_t *obj, uint32_t Sector)
 {
   XSPI_HandleTypeDef *handle = &(obj->handle);
 
-  if (Sector >= (uint32_t)(MX25R6435F_FLASH_SIZE/MX25R6435F_SECTOR_SIZE))
-  {
+  if (Sector >= (uint32_t)(MX25R6435F_FLASH_SIZE / MX25R6435F_SECTOR_SIZE)) {
     return QSPI_ERROR;
   }
 
@@ -695,8 +596,7 @@ uint8_t BSP_QSPI_GetStatus(QSPI_t *obj)
   /* Check the value of the register */
   if ((reg & (MX25R6435F_SECR_P_FAIL | MX25R6435F_SECR_E_FAIL)) != 0) {
     return QSPI_ERROR;
-  }
-  else if ((reg & (MX25R6435F_SECR_PSB | MX25R6435F_SECR_ESB)) != 0) {
+  } else if ((reg & (MX25R6435F_SECR_PSB | MX25R6435F_SECR_ESB)) != 0) {
     return QSPI_SUSPENDED;
   }
 
@@ -726,14 +626,14 @@ uint8_t BSP_QSPI_GetStatus(QSPI_t *obj)
   * @param  pInfo : pointer on the configuration structure
   * @retval QSPI memory status
   */
-uint8_t BSP_QSPI_GetInfo(QSPI_Info* pInfo)
+uint8_t BSP_QSPI_GetInfo(QSPI_Info *pInfo)
 {
   /* Configure the structure with the memory configuration */
   pInfo->FlashSize          = MX25R6435F_FLASH_SIZE;
   pInfo->EraseSectorSize    = MX25R6435F_SECTOR_SIZE;
-  pInfo->EraseSectorsNumber = (MX25R6435F_FLASH_SIZE/MX25R6435F_SECTOR_SIZE);
+  pInfo->EraseSectorsNumber = (MX25R6435F_FLASH_SIZE / MX25R6435F_SECTOR_SIZE);
   pInfo->ProgPageSize       = MX25R6435F_PAGE_SIZE;
-  pInfo->ProgPagesNumber    = (MX25R6435F_FLASH_SIZE/MX25R6435F_PAGE_SIZE);
+  pInfo->ProgPagesNumber    = (MX25R6435F_FLASH_SIZE / MX25R6435F_PAGE_SIZE);
 
   return QSPI_OK;
 }
@@ -834,8 +734,7 @@ uint8_t BSP_QSPI_SuspendErase(QSPI_t *obj)
   /* Check whether the device is busy (erase operation is
   in progress).
   */
-  if (BSP_QSPI_GetStatus(obj) == QSPI_BUSY)
-  {
+  if (BSP_QSPI_GetStatus(obj) == QSPI_BUSY) {
 #ifdef OCTOSPI
     OSPI_RegularCmdTypeDef sCommand;
 
@@ -891,8 +790,7 @@ uint8_t BSP_QSPI_ResumeErase(QSPI_t *obj)
   XSPI_HandleTypeDef *handle = &(obj->handle);
 
   /* Check whether the device is in suspended state */
-  if (BSP_QSPI_GetStatus(obj) == QSPI_SUSPENDED)
-  {
+  if (BSP_QSPI_GetStatus(obj) == QSPI_SUSPENDED) {
 #ifdef OCTOSPI
     OSPI_RegularCmdTypeDef sCommand;
 
@@ -1054,8 +952,8 @@ __weak void BSP_QSPI_MspInit(QSPI_t *obj)
 {
 #ifdef OCTOSPI
 
-    /* Enable the OctoSPI memory interface clock */
-    /* Reset the OctoSPI memory interface */
+  /* Enable the OctoSPI memory interface clock */
+  /* Reset the OctoSPI memory interface */
 #if defined(OCTOSPI1)
   if (obj->qspi == OCTOSPI1) {
     __HAL_RCC_OSPI1_CLK_ENABLE();
@@ -1134,14 +1032,6 @@ __weak void BSP_QSPI_MspDeInit(QSPI_t *obj)
   __HAL_RCC_QSPI_CLK_DISABLE();
 #endif /* OCTOSPI */
 }
-
-/**
-  * @}
-  */
-
-/** @addtogroup STM32L475E_IOT01_QSPI_Private_Functions
-  * @{
-  */
 
 /**
   * @brief  This function reset the QSPI memory.
@@ -1564,22 +1454,6 @@ static uint8_t QSPI_HighPerfMode(XSPI_HandleTypeDef *hxspi, uint8_t Operation)
 
   return QSPI_OK;
 }
-
-/**
-  * @}
-  */
-
-/**
-  * @}
-  */
-
-/**
-  * @}
-  */
-
-/**
-  * @}
-  */
 
 #ifdef __cplusplus
 }

--- a/src/mx25r6435f_driver.h
+++ b/src/mx25r6435f_driver.h
@@ -79,6 +79,10 @@
 #define PinMap_XSPI_SSEL    PinMap_OCTOSPI_SSEL
 #define HAL_XSPI_Init       HAL_OSPI_Init
 #define HAL_XSPI_DeInit     HAL_OSPI_DeInit
+#define HAL_XSPI_TIMEOUT_DEFAULT_VALUE HAL_OSPI_TIMEOUT_DEFAULT_VALUE
+#define HAL_XSPI_Command    HAL_OSPI_Command
+#define HAL_XSPI_Transmit   HAL_OSPI_Transmit
+#define HAL_XSPI_Receive    HAL_OSPI_Receive
 #elif defined(QUADSPI)
 #define XSPI_HandleTypeDef  QSPI_HandleTypeDef
 #define XSPI_TypeDef        QUADSPI_TypeDef
@@ -90,6 +94,10 @@
 #define PinMap_XSPI_SSEL    PinMap_QUADSPI_SSEL
 #define HAL_XSPI_Init       HAL_QSPI_Init
 #define HAL_XSPI_DeInit     HAL_QSPI_DeInit
+#define HAL_XSPI_TIMEOUT_DEFAULT_VALUE HAL_QPSI_TIMEOUT_DEFAULT_VALUE
+#define HAL_XSPI_Command    HAL_QSPI_Command
+#define HAL_XSPI_Transmit   HAL_QSPI_Transmit
+#define HAL_XSPI_Receive    HAL_QSPI_Receive
 #else
 #error "QSPI feature not available. MX25R6435F library compilation failed."
 #endif /* OCTOSPIx */

--- a/src/mx25r6435f_driver.h
+++ b/src/mx25r6435f_driver.h
@@ -1,37 +1,18 @@
 /**
   ******************************************************************************
   * @file    mx25r6435f_driver.h
-  * @author  MCD Application Team
-  * @version V1.1.0
-  * @date    21-April-2017
   * @brief   This file contains the common defines and functions prototypes for
   *          the mx25r6435f_driver.c driver.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+  * <h2><center>&copy; Copyright (c) 2020 STMicroelectronics.
+  * All rights reserved.</center></h2>
   *
-  * Redistribution and use in source and binary forms, with or without modification,
-  * are permitted provided that the following conditions are met:
-  *   1. Redistributions of source code must retain the above copyright notice,
-  *      this list of conditions and the following disclaimer.
-  *   2. Redistributions in binary form must reproduce the above copyright notice,
-  *      this list of conditions and the following disclaimer in the documentation
-  *      and/or other materials provided with the distribution.
-  *   3. Neither the name of STMicroelectronics nor the names of its contributors
-  *      may be used to endorse or promote products derived from this software
-  *      without specific prior written permission.
-  *
-  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  * This software component is licensed by ST under BSD 3-Clause license,
+  * the "License"; You may not use this file except in compliance with the
+  * License. You may obtain a copy of the License at:
+  *                        opensource.org/licenses/BSD-3-Clause
   *
   ******************************************************************************
   */
@@ -41,7 +22,7 @@
 #define _MX25R6435F_DRIVER_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
@@ -49,24 +30,7 @@
 #include "PeripheralPins.h"
 #include "mx25r6435f_desc.h"
 
-
-/** @addtogroup BSP
-  * @{
-  */
-
-/** @addtogroup STM32L475E_IOT01
-  * @{
-  */
-
-/** @addtogroup STM32L475E_IOT01_QSPI
-  * @{
-  */
-
 /* Exported constants --------------------------------------------------------*/
-/** @defgroup STM32L475E_IOT01_QSPI_Exported_Constants QSPI Exported Constants
-  * @{
-  */
-
 #if defined(OCTOSPI1) || defined(OCTOSPI2)
 #define OCTOSPI
 #define XSPI_HandleTypeDef  OSPI_HandleTypeDef
@@ -109,14 +73,7 @@
 #define QSPI_NOT_SUPPORTED ((uint8_t)0x04)
 #define QSPI_SUSPENDED     ((uint8_t)0x08)
 
-/**
-  * @}
-  */
-
 /* Exported types ------------------------------------------------------------*/
-/** @defgroup STM32L475E_IOT01_QSPI_Exported_Types QSPI Exported Types
-  * @{
-  */
 /* QSPI Info */
 typedef struct {
   uint32_t FlashSize;          /*!< Size of the flash */
@@ -138,46 +95,24 @@ typedef struct {
   PinName pin_ssel;
 } QSPI_t;
 
-/**
-  * @}
-  */
-
 /* Exported functions --------------------------------------------------------*/
-/** @defgroup STM32L475E_IOT01_QSPI_Exported_Functions QSPI Exported Functions
-  * @{
-  */
-uint8_t BSP_QSPI_Init                  (QSPI_t *obj);
-uint8_t BSP_QSPI_DeInit                (QSPI_t *obj);
-uint8_t BSP_QSPI_Read                  (QSPI_t *obj, uint8_t* pData, uint32_t ReadAddr, uint32_t Size);
-uint8_t BSP_QSPI_Write                 (QSPI_t *obj, uint8_t* pData, uint32_t WriteAddr, uint32_t Size);
-uint8_t BSP_QSPI_Erase_Block           (QSPI_t *obj, uint32_t BlockAddress);
-uint8_t BSP_QSPI_Erase_Sector          (QSPI_t *obj, uint32_t Sector);
-uint8_t BSP_QSPI_Erase_Chip            (QSPI_t *obj);
-uint8_t BSP_QSPI_GetStatus             (QSPI_t *obj);
-uint8_t BSP_QSPI_GetInfo               (QSPI_Info* pInfo);
+uint8_t BSP_QSPI_Init(QSPI_t *obj);
+uint8_t BSP_QSPI_DeInit(QSPI_t *obj);
+uint8_t BSP_QSPI_Read(QSPI_t *obj, uint8_t *pData, uint32_t ReadAddr, uint32_t Size);
+uint8_t BSP_QSPI_Write(QSPI_t *obj, uint8_t *pData, uint32_t WriteAddr, uint32_t Size);
+uint8_t BSP_QSPI_Erase_Block(QSPI_t *obj, uint32_t BlockAddress);
+uint8_t BSP_QSPI_Erase_Sector(QSPI_t *obj, uint32_t Sector);
+uint8_t BSP_QSPI_Erase_Chip(QSPI_t *obj);
+uint8_t BSP_QSPI_GetStatus(QSPI_t *obj);
+uint8_t BSP_QSPI_GetInfo(QSPI_Info *pInfo);
 uint8_t BSP_QSPI_EnableMemoryMappedMode(QSPI_t *obj);
-uint8_t BSP_QSPI_SuspendErase          (QSPI_t *obj);
-uint8_t BSP_QSPI_ResumeErase           (QSPI_t *obj);
-uint8_t BSP_QSPI_EnterDeepPowerDown    (QSPI_t *obj);
-uint8_t BSP_QSPI_LeaveDeepPowerDown    (QSPI_t *obj);
+uint8_t BSP_QSPI_SuspendErase(QSPI_t *obj);
+uint8_t BSP_QSPI_ResumeErase(QSPI_t *obj);
+uint8_t BSP_QSPI_EnterDeepPowerDown(QSPI_t *obj);
+uint8_t BSP_QSPI_LeaveDeepPowerDown(QSPI_t *obj);
 
 void BSP_QSPI_MspInit(QSPI_t *obj);
 void BSP_QSPI_MspDeInit(QSPI_t *obj);
-/**
-  * @}
-  */
-
-/**
-  * @}
-  */
-
-/**
-  * @}
-  */
-
-/**
-  * @}
-  */
 
 #ifdef __cplusplus
 }

--- a/src/mx25r6435f_driver.h
+++ b/src/mx25r6435f_driver.h
@@ -46,18 +46,9 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32_def.h"
+#include "PeripheralPins.h"
 #include "mx25r6435f_desc.h"
 
-#if defined(OCTOSPI1)
-#define OCTOSPI OCTOSPI1
-#elif defined(OCTOSPI2)
-#define OCTOSPI OCTOSPI2
-#else
-/* Checks if QSPI available */
-#ifndef QUADSPI
-#error "QSPI not available. MX25R6435F library compilation failed."
-#endif /* QSPI */
-#endif /* OSPI */
 
 /** @addtogroup BSP
   * @{
@@ -75,6 +66,34 @@
 /** @defgroup STM32L475E_IOT01_QSPI_Exported_Constants QSPI Exported Constants
   * @{
   */
+
+#if defined(OCTOSPI1) || defined(OCTOSPI2)
+#define OCTOSPI
+#define XSPI_HandleTypeDef  OSPI_HandleTypeDef
+#define XSPI_TypeDef        OCTOSPI_TypeDef
+#define PinMap_XSPI_DATA0   PinMap_OCTOSPI_DATA0
+#define PinMap_XSPI_DATA1   PinMap_OCTOSPI_DATA1
+#define PinMap_XSPI_DATA2   PinMap_OCTOSPI_DATA2
+#define PinMap_XSPI_DATA3   PinMap_OCTOSPI_DATA3
+#define PinMap_XSPI_SCLK    PinMap_OCTOSPI_SCLK
+#define PinMap_XSPI_SSEL    PinMap_OCTOSPI_SSEL
+#define HAL_XSPI_Init       HAL_OSPI_Init
+#define HAL_XSPI_DeInit     HAL_OSPI_DeInit
+#elif defined(QUADSPI)
+#define XSPI_HandleTypeDef  QSPI_HandleTypeDef
+#define XSPI_TypeDef        QUADSPI_TypeDef
+#define PinMap_XSPI_DATA0   PinMap_QUADSPI_DATA0
+#define PinMap_XSPI_DATA1   PinMap_QUADSPI_DATA1
+#define PinMap_XSPI_DATA2   PinMap_QUADSPI_DATA2
+#define PinMap_XSPI_DATA3   PinMap_QUADSPI_DATA3
+#define PinMap_XSPI_SCLK    PinMap_QUADSPI_SCLK
+#define PinMap_XSPI_SSEL    PinMap_QUADSPI_SSEL
+#define HAL_XSPI_Init       HAL_QSPI_Init
+#define HAL_XSPI_DeInit     HAL_QSPI_DeInit
+#else
+#error "QSPI feature not available. MX25R6435F library compilation failed."
+#endif /* OCTOSPIx */
+
 /* QSPI Error codes */
 #define QSPI_OK            ((uint8_t)0x00)
 #define QSPI_ERROR         ((uint8_t)0x01)
@@ -99,6 +118,18 @@ typedef struct {
   uint32_t ProgPagesNumber;    /*!< Number of pages for the program operation */
 } QSPI_Info;
 
+
+typedef struct {
+  XSPI_HandleTypeDef handle;
+  XSPI_TypeDef *qspi;
+  PinName pin_d0;
+  PinName pin_d1;
+  PinName pin_d2;
+  PinName pin_d3;
+  PinName pin_sclk;
+  PinName pin_ssel;
+} QSPI_t;
+
 /**
   * @}
   */
@@ -107,23 +138,23 @@ typedef struct {
 /** @defgroup STM32L475E_IOT01_QSPI_Exported_Functions QSPI Exported Functions
   * @{
   */
-uint8_t BSP_QSPI_Init                  (void);
-uint8_t BSP_QSPI_DeInit                (void);
-uint8_t BSP_QSPI_Read                  (uint8_t* pData, uint32_t ReadAddr, uint32_t Size);
-uint8_t BSP_QSPI_Write                 (uint8_t* pData, uint32_t WriteAddr, uint32_t Size);
-uint8_t BSP_QSPI_Erase_Block           (uint32_t BlockAddress);
-uint8_t BSP_QSPI_Erase_Sector          (uint32_t Sector);
-uint8_t BSP_QSPI_Erase_Chip            (void);
-uint8_t BSP_QSPI_GetStatus             (void);
+uint8_t BSP_QSPI_Init                  (QSPI_t *obj);
+uint8_t BSP_QSPI_DeInit                (QSPI_t *obj);
+uint8_t BSP_QSPI_Read                  (QSPI_t *obj, uint8_t* pData, uint32_t ReadAddr, uint32_t Size);
+uint8_t BSP_QSPI_Write                 (QSPI_t *obj, uint8_t* pData, uint32_t WriteAddr, uint32_t Size);
+uint8_t BSP_QSPI_Erase_Block           (QSPI_t *obj, uint32_t BlockAddress);
+uint8_t BSP_QSPI_Erase_Sector          (QSPI_t *obj, uint32_t Sector);
+uint8_t BSP_QSPI_Erase_Chip            (QSPI_t *obj);
+uint8_t BSP_QSPI_GetStatus             (QSPI_t *obj);
 uint8_t BSP_QSPI_GetInfo               (QSPI_Info* pInfo);
-uint8_t BSP_QSPI_EnableMemoryMappedMode(void);
-uint8_t BSP_QSPI_SuspendErase          (void);
-uint8_t BSP_QSPI_ResumeErase           (void);
-uint8_t BSP_QSPI_EnterDeepPowerDown    (void);
-uint8_t BSP_QSPI_LeaveDeepPowerDown    (void);
+uint8_t BSP_QSPI_EnableMemoryMappedMode(QSPI_t *obj);
+uint8_t BSP_QSPI_SuspendErase          (QSPI_t *obj);
+uint8_t BSP_QSPI_ResumeErase           (QSPI_t *obj);
+uint8_t BSP_QSPI_EnterDeepPowerDown    (QSPI_t *obj);
+uint8_t BSP_QSPI_LeaveDeepPowerDown    (QSPI_t *obj);
 
-void BSP_QSPI_MspInit(void);
-void BSP_QSPI_MspDeInit(void);
+void BSP_QSPI_MspInit(QSPI_t *obj);
+void BSP_QSPI_MspDeInit(QSPI_t *obj);
 /**
   * @}
   */

--- a/src/mx25r6435f_driver.h
+++ b/src/mx25r6435f_driver.h
@@ -48,10 +48,16 @@
 #include "stm32_def.h"
 #include "mx25r6435f_desc.h"
 
+#if defined(OCTOSPI1)
+#define OCTOSPI OCTOSPI1
+#elif defined(OCTOSPI2)
+#define OCTOSPI OCTOSPI2
+#else
 /* Checks if QSPI available */
 #ifndef QUADSPI
 #error "QSPI not available. MX25R6435F library compilation failed."
-#endif
+#endif /* QSPI */
+#endif /* OSPI */
 
 /** @addtogroup BSP
   * @{

--- a/src/mx25r6435f_driver.h
+++ b/src/mx25r6435f_driver.h
@@ -50,12 +50,22 @@ extern "C" {
 #elif defined(QUADSPI)
 #define XSPI_HandleTypeDef  QSPI_HandleTypeDef
 #define XSPI_TypeDef        QUADSPI_TypeDef
+
+#if defined(STM32_CORE_VERSION) && (STM32_CORE_VERSION  > 0x01090000)
 #define PinMap_XSPI_DATA0   PinMap_QUADSPI_DATA0
 #define PinMap_XSPI_DATA1   PinMap_QUADSPI_DATA1
 #define PinMap_XSPI_DATA2   PinMap_QUADSPI_DATA2
 #define PinMap_XSPI_DATA3   PinMap_QUADSPI_DATA3
 #define PinMap_XSPI_SCLK    PinMap_QUADSPI_SCLK
 #define PinMap_XSPI_SSEL    PinMap_QUADSPI_SSEL
+#else
+#define PinMap_XSPI_DATA0   PinMap_QUADSPI
+#define PinMap_XSPI_DATA1   PinMap_QUADSPI
+#define PinMap_XSPI_DATA2   PinMap_QUADSPI
+#define PinMap_XSPI_DATA3   PinMap_QUADSPI
+#define PinMap_XSPI_SCLK    PinMap_QUADSPI
+#define PinMap_XSPI_SSEL    PinMap_QUADSPI
+#endif
 #define HAL_XSPI_Init       HAL_QSPI_Init
 #define HAL_XSPI_DeInit     HAL_QSPI_DeInit
 #define HAL_XSPI_TIMEOUT_DEFAULT_VALUE HAL_QPSI_TIMEOUT_DEFAULT_VALUE


### PR DESCRIPTION
L4S5 IOT kit has octospi feature to access the hw mx2556435f
the 64-Mbit Quad-SPI Flash memory from Macronix
Takes code from the ./STM32CubeL4/Drivers/BSP/B-L4S5I-IOT01/stm32l4s5i_iot01_qspi.c/.h

requires https://github.com/stm32duino/Arduino_Core_STM32/pull/1163